### PR TITLE
revert changes to signed/unsigned comparison

### DIFF
--- a/src/Evolution/GenerationHandler.cpp
+++ b/src/Evolution/GenerationHandler.cpp
@@ -180,7 +180,7 @@ std::vector<Node*> GenerationHandler::MakeOffspring(const std::vector<Node *> & 
     return offspring;
 }
 
-bool GenerationHandler::ValidateOffspring(Node* offspring, size_t max_height, size_t max_size) {
+bool GenerationHandler::ValidateOffspring(Node* offspring, int max_height, int  max_size) {
 
     if (max_height > -1) {
         if (offspring->GetHeight() > max_height) {

--- a/src/GOMEA/GOMEAFOS.cpp
+++ b/src/GOMEA/GOMEAFOS.cpp
@@ -51,7 +51,7 @@ std::vector<std::vector<size_t>> GOMEAFOS::BuildLinkageTreeFromSimilarityMatrix(
 
     vector<vector < int >> mpm(number_of_nodes, vector<int>(1));
     vector<int> mpm_number_of_indices(number_of_nodes);
-    size_t mpm_length = number_of_nodes;
+    int mpm_length = number_of_nodes;
 
     for (size_t i = 0; i < number_of_nodes; i++) {
         mpm[i][0] = random_order[i];
@@ -76,7 +76,7 @@ std::vector<std::vector<size_t>> GOMEAFOS::BuildLinkageTreeFromSimilarityMatrix(
 
     vector<vector < int >> mpm_new;
     vector<int> NN_chain(number_of_nodes + 2, 0);
-    size_t NN_chain_length = 0;
+    int NN_chain_length = 0;
     short done = 0;
 
     while (!done) {

--- a/src/Genotype/Node.cpp
+++ b/src/Genotype/Node.cpp
@@ -299,7 +299,7 @@ std::vector<arma::vec> Node::GetDesiredOutput(const std::vector<arma::vec> & Y, 
     }
 
     size_t idx = GetRelativeIndex();
-    size_t num_siblings = parent->GetArity() - 1;
+    int num_siblings = parent->GetArity() - 1;
     arma::mat output_siblings(X.n_rows, num_siblings);
 
     size_t j = 0;

--- a/src/Include/GPGOMEA/Evolution/GenerationHandler.h
+++ b/src/Include/GPGOMEA/Evolution/GenerationHandler.h
@@ -40,7 +40,7 @@ public:
     virtual bool CheckPopulationConverged(const std::vector<Node*>& population);
 
     std::vector<Node*> MakeOffspring(const std::vector<Node *> & population, const std::vector<Node*> & parents);
-    bool ValidateOffspring(Node * offspring, size_t max_height, size_t max_size);
+    bool ValidateOffspring(Node * offspring, int max_height, int max_size);
 
     ConfigurationOptions * conf;
     TreeInitializer * tree_initializer;


### PR DESCRIPTION
revert changes signed/unsigned comparisions. which repairs the ValidateOffspring function. Other changes out of precaution. 